### PR TITLE
Update movefolder-handback.yml

### DIFF
--- a/learn-test-sandbox/cotentbrowsetest/modules/TestFolder/movefolder-handback.yml
+++ b/learn-test-sandbox/cotentbrowsetest/modules/TestFolder/movefolder-handback.yml
@@ -19,5 +19,6 @@ products:
 - m365 
 units: 
 - learn-test-sandbox.fallback.zhcntest.browsetestloc
+- learn-test-sandbox.moveFolderZhCn.handback-already.browsetest
 badge: 
   uid: learn-test-sandbox.browsetestloc2.badge.231 


### PR DESCRIPTION
- parent unit 'learn-test-sandbox.moveFolderZhCn.handback-already.browsetest' to this module to fix build failure issue.